### PR TITLE
fix: retry activating hermit if it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hermit buildkite plugin
 
-Activate hermit environment to use and manage packages
+Activate hermit environment to use and manage packages.
+
+Will retry hermit activation up to `max_retries` times with a delay of
+`retry_delay` seconds between retries. Set `max_retries` to `0` to disable
+retries.
 
 ## Example
 
@@ -10,5 +14,12 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - elastic/hermit#v1.0.0
+      - elastic/hermit#v1.0.3
 ```
+
+## Configuration
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `max_retries` | The maximum number of retries for hermit activation | `3` |
+| `retry_delay` | The number of seconds to wait between retries | `1` |

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -3,4 +3,23 @@
 set -euo pipefail
 
 echo "~~~ Init Hermit environment"
-. bin/activate-hermit && export PATH="$PATH:/var/lib/buildkite-agent/bin"
+
+max_retries=${BUILDKITE_PLUGIN_HERMIT_MAX_RETRIES:-3}
+retry_delay=${BUILDKITE_PLUGIN_HERMIT_RETRY_DELAY:-1}
+
+retries=0
+while [ "$retries" -le "$max_retries" ]; do
+  if . bin/activate-hermit; then
+    break
+  else
+    if [ "$retries" -eq "$max_retries" ]; then
+      echo "Failed to activate Hermit environment after $max_retries attempts"
+      exit 1
+    fi
+    echo "Failed to activate Hermit environment, retrying in $retry_delay seconds..."
+    sleep "$retry_delay"
+  fi
+  retries=$((retries + 1))
+done
+
+export PATH="$PATH:/var/lib/buildkite-agent/bin"

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,5 +3,13 @@ description: Activate hermit environment to use and manage packages
 author: https://github.com/navyau09
 requirements: []
 configuration:
-  properties: {}
+  properties:
+    max_retries:
+      type: number
+      default: 3
+      description: The maximum number of retries for hermit activation
+    retry_delay:
+      type: number
+      default: 1
+      description: The number of seconds to wait between retries
   additionalProperties: false


### PR DESCRIPTION
There are times that hermit fails to activate with a 504 error. Instead of having the buildkite step fail, retry the activation.

We have seen these errors from time to time:
```
Bootstrapping /root/.cache/hermit/pkg/hermit@stable/hermit from https://github.com/cashapp/hermit/releases/download/stable
curl: (22) The requested URL returned error: 504
```

The resulting behaviour is that Buildkite continues executing steps in the pipeline but they are doomed to fail because the binaries they depend on will not be in the path. This PR looks to remedy that situation by retrying `. bin/activate-hermit` if it fails. 