### PR TITLE
Migration: reassign team ownership to @elastic/ci-systems (please review)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-*       @elastic/platform-dev-flow
+*       @elastic/ci-systems

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:platform-dev-flow
+  owner: group:ci-systems
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -24,7 +24,7 @@ spec:
       repository: elastic/hermit-buildkite-plugin
       pipeline_file: ".buildkite/pipeline.yaml"
       teams:
-        platform-dev-flow:
+        ci-systems:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -19,7 +19,7 @@ spec:
     kind: Pipeline
     metadata:
       name: hermit-buildkite-plugin
-      description: 
+      description: ""
     spec:
       repository: elastic/hermit-buildkite-plugin
       pipeline_file: ".buildkite/pipeline.yaml"


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.

### Please double-check — classified as `complex`

This repo had multiple changing-team signals (e.g., several old admins, or `catalog-info.yaml` and `catalog.yaml` owners disagree). The mechanical rewrite assigns everything to **@elastic/ci-systems** based on `migration-data.yaml`. Please confirm that's what you want before approving.

### Files changed

- `.github/CODEOWNERS` (1 line)
- `catalog-info.yaml` (2 lines)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.